### PR TITLE
up rollup live reload version to 1.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "npm-run-all": "^4.1.5",
     "rollup": "^1.12.0",
     "rollup-plugin-commonjs": "^10.0.0",
-    "rollup-plugin-livereload": "^1.0.0",
+    "rollup-plugin-livereload": "^1.0.4",
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-svelte": "^5.0.3",
     "rollup-plugin-terser": "^4.0.4",


### PR DESCRIPTION
rollup live reload is currently at 1.0.4, upgrading to that version